### PR TITLE
Tweak/trigger postinstall commands only when required

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -29,7 +29,7 @@ Note: The versions represented in the table are only for example and may not rep
 | [alsacap](https://github.com/bubbapizza/alsacap)    | 1.0.1-1moode1  | git+dh_make |  |
 | [ashuffle](https://github.com/joshkunz/ashuffle)   | 3.12.5-1moode1 | git+dh_make |  |
 | [*bluez*](https://github.com/bluez/bluez)      | *5.55-3.1+rpt1* | ***stock*** |
-| [bluez-alsa](https://github.com/Arkq/bluez-alsa) | 3.0.0-2moode1  | backport    |  |
+| [bluez-alsa](https://github.com/Arkq/bluez-alsa) | 4.0.0-1moode1  | git+debscr  |  |
 | [camilladsp](https://github.com/HEnquist/camilladsp) | 1.0.3-1moode1  | cargo-deb   |  |
 | [camillagui](https://github.com/HEnquist/camillagui) | 1.0.1-1moode3  | fpm   | yes |
 | [*camillagui-backend*](https://github.com/HEnquist/camillagui-backend) | *1.0.1-1moode1*  | *-*  | *yes* |
@@ -42,7 +42,7 @@ Note: The versions represented in the table are only for example and may not rep
 | [moode-player](https://github.com/moode-player/moode)       | 8.2.5-1moode1 | git+dh_make     |  |
 | [*mpc*](https://www.musicpd.org/)        | *0.33.1* | ***stock*** |
 | [mpd](https://www.musicpd.org/)        | 0.23.12-1moode1 | backport    | yes |
-| [mpd2cdspvolume](https://github.com/bitkeeper/mpd2cdspvolume/)        | 0.1.0-1moode1 | fpm    | no |
+| [mpd2cdspvolume](https://github.com/bitkeeper/mpd2cdspvolume/)        | 0.1.2-1moode1 | fpm    | no |
 | [nqptp](https://github.com/mikebrady/nqptp)        | 1.1.0~git20220930.c71b49a-1moode1 | git+dh_make    |  |
 | [python3-camilladsp](https://github.com/HEnquist/pycamilladsp) | 1.0.0-1moode1 | stdeb |  |
 | [python3-camilladsp-plot](https://github.com/HEnquist/pycamilladsp-plot) | 1.0.0-1moode1 | stdeb |  |

--- a/packages/bluez-alsa/build.sh
+++ b/packages/bluez-alsa/build.sh
@@ -3,23 +3,37 @@
 #
 # Build recipe for bluez-alsa debian package
 #
-# (C) bitkeeper 2021 http://moodeaudio.org
+# (C) bitkeeper 2023 http://moodeaudio.org
 # License: GPLv3
+#
+# While 3.0.2 was just a rebuild from a dsc, for 4.0.0:
+#  - the deb skeleton files from 3.0.2 are used
+#  - Source from the git repo are used
 #
 #########################################################################
 
 
 . ../../scripts/rebuilder.lib.sh
 
-PKG_DSC_URL="http://deb.debian.org/debian/pool/main/b/bluez-alsa/bluez-alsa_3.0.0-2.dsc"
+PKG="bluez-alsa_4.0.0-1moode1"
 
-rbl_prepare_from_dsc_url $PKG_DSC_URL
+PKG_SOURCE_GIT="https://github.com/arkq/bluez-alsa.git"
+PKG_SOURCE_GIT_TAG="v4.0.0"
+
+PKG_DEBIAN="http://deb.debian.org/debian/pool/main/b/bluez-alsa/bluez-alsa_3.0.0-2.debian.tar.xz"
+
+
+rbl_prepare_from_git_with_deb_repo
 
 #------------------------------------------------------------
 # Custom part of the packing
 
-# set debian local suffix flag
-DEBFULLNAME=$DEBFULLNAME DEBEMAIL=$DEBEMAIL dch --local $DEBSUFFIX "Rebuild for moOde bullseye"
+# grab debian dir of older version
+rbl_grab_debian_archive $PKG_DEBIAN
+
+echo "usr/share/man/man7/bluealsa-plugins.7" >> debian/bluez-alsa-utils.manpages
+
+DEBFULLNAME=$DEBFULLNAME DEBEMAIL=$DEBEMAIL dch --newversion $FULL_VERSION "Build for moOde."
 
 #------------------------------------------------------------
 

--- a/packages/mpd2cdspvolume/build.sh
+++ b/packages/mpd2cdspvolume/build.sh
@@ -11,10 +11,10 @@
 . ../../scripts/rebuilder.lib.sh
 
 
-PKG="mpd2cdspvolume_0.1.0-1moode1"
+PKG="mpd2cdspvolume_0.1.2-1moode1"
 
 PKG_SOURCE_GIT="https://github.com/bitkeeper/mpd2cdspvolume.git"
-PKG_SOURCE_GIT_TAG="v0.1.0"
+PKG_SOURCE_GIT_TAG="v0.1.2"
 
 rbl_prepare_clone_from_git $PKG_SOURCE_GIT $PKG_SOURCE_GIT_TAG
 


### PR DESCRIPTION
Surround each version update block with anif to only execute it when required.

This prevents updates running multiple times and restoring some values each time on a update.

```bash
      dpkg --compare-versions $VERSION lt "8.x.y-zmoode1"
      if [ $? -eq 0 ]
      then
         # update command for specific version
      fi
```