### PR TITLE
Fix big channel update;move the reference from 9.0.0 to 9.1.4

### DIFF
--- a/packages/moode-player/build.sh
+++ b/packages/moode-player/build.sh
@@ -27,7 +27,7 @@ BUILD_APP=1
 GULP_BIN=$MOODE_DIR/node_modules/.bin/gulp
 
 # Used as reference for generating station patch files. Should be the first releas of a major
-MAJOR_BASE_STATIONS=../dist/binary/moode-stations-full_9.0.0.zip
+MAJOR_BASE_STATIONS=../dist/binary/moode-stations-full_9.1.4.zip
 
 # ----------------------------------------------------------------------------
 # 1. Prepare pacakge build dir and build deps

--- a/packages/moode-player/postinstall.sh
+++ b/packages/moode-player/postinstall.sh
@@ -640,6 +640,10 @@ function on_upgrade() {
     cp -f $SRC/etc/update-motd.d/00-moodeos-header /etc/update-motd.d/
 
     # Update radio stations and logos
+    dpkg --compare-versions $VERSION lt "9.1.4-1moode1"
+    if [ $? -eq 0 ]; then
+        import_stations update "https://dl.cloudsmith.io/public/moodeaudio/m8y/raw/files/moode-stations-update-9.1.4.zip"
+    fi
     import_stations update "https://dl.cloudsmith.io/public/moodeaudio/m8y/raw/files/moode-stations-update_$PKG_VERSION.zip"
 
     # Set permissions for service files


### PR DESCRIPTION
Since the supplying images updates for all station, the stations updates are big because it always contains the images again the ref 9.0.0.

We can fix this by moving the reference to 9.1.4, so the updat only contains changes starting from 9.1.4.
When updating from a version before 9.1.4, first the 9.1.4 update is done.