### PR TITLE
[pleezer] add initial build script

### DIFF
--- a/packages/pleezer/build.sh
+++ b/packages/pleezer/build.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#########################################################################
+#
+# Build recipe for pleezer debian package
+#
+# (C) bitkeeper 2024 http://moodeaudio.org
+# License: GPLv3
+#
+#########################################################################
+
+. ../../scripts/rebuilder.lib.sh
+
+PKG="pleezer_0.2.0-1moode1"
+
+PKG_SOURCE_GIT="https://github.com/roderickvd/pleezer.git"
+PKG_SOURCE_GIT_TAG="v0.2.0"
+
+rbl_check_cargo
+rbl_prepare_clone_from_git ${PKG_SOURCE_GIT} ${PKG_SOURCE_GIT_TAG}
+rbl_create_git_archive ${PKG_SOURCE_GIT_TAG} ../${PKGNAME}_${PKGVERSION}.orig.tar.gz
+
+# ------------------------------------------------------------
+# Custom part of the packing
+
+#Add to [package.metadata.deb] section of Cargo.toml:
+# sed -i "s/^priority = \"optional\"/priority = \"optional\"\nrevision = \"${DEBVER}${DEBLOC}\"/" Cargo.toml
+# if [[ $? -gt 0 ]]
+# then
+#     echo "${RED}Error: sed failed to set correct PKG VERSION!${NORMAL}"
+#     exit
+# fi
+echo -e "\n[package.metadata.deb]\n\
+revision = \"${DEBVER}${DEBLOC}\" \
+ " >> Cargo.toml
+
+
+RUSTFLAGS='-Ccodegen-units=1' cargo-deb --
+
+if [[ $? -gt 0 ]]
+then
+    echo "${RED}Error: cargo-deb failed during build${NORMAL}"
+    exit
+fi
+
+mv target/debian/pleezer*.deb ..
+/build/pleezer-0.2.0/target/debian/pleezer_0.2.0_arm64.deb
+#------------------------------------------------------------
+# post_build
+rbl_move_to_dist
+
+echo "done"

--- a/scripts/rebuilder.lib.sh
+++ b/scripts/rebuilder.lib.sh
@@ -256,6 +256,7 @@ function _rbl_check_build_deps {
 
 function _build_deb {
     # build package
+    # DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -us -uc
     dpkg-buildpackage -us -uc
     if [[ $? -gt 0 ]]
     then
@@ -295,7 +296,7 @@ function rbl_check_cargo {
     export RUSTUP_UNPACK_RAM=94371840; export RUSTUP_IO_THREADS=1
     export PATH=$PATH:/home/pi/.cargo/bin
 
-    RUSTC_MIN_VERSION="1.65"
+    RUSTC_MIN_VERSION="1.82"
     # RUST_CHAIN="nightly"
     # until 1.61 is available on stable switch to nightly
     RUST_CHAIN="stable"
@@ -340,23 +341,6 @@ function rbl_check_cargo {
         echo "${GREEN}cargo-deb: already installed${NORMAL}"
     fi
 
-    rustup show | grep $RUST_CHAIN-armv7-unknown-linux-gnueabihf > /dev/null
-    if [[ $? -gt 0 ]]
-    then
-        echo "${YELLOW}rustup: armv7 toolchain not installed, installing it.${NORMAL}"a
-        rustup toolchain install stable-armv7-unknown-linux-gnueabihf
-    else
-        echo "${GREEN}rustup: armv7 toolchain already installed${NORMAL}"
-    fi
-
-    rustup show | grep $RUST_CHAIN-arm-unknown-linux-gnueabihf > /dev/null
-    if [[ $? -gt 0 ]]
-    then
-        echo "${YELLOW}rustup: armv6 toolchain not installed, installing it.${NORMAL}"a
-        rustup toolchain install stable-arm-unknown-linux-gnueabihf
-    else
-        echo "${GREEN}rustup: armv6 toolchain already installed${NORMAL}"
-    fi
 }
 
 function rbl_check_fpm {


### PR DESCRIPTION
Initial build script for [pleezer](https://github.com/roderickvd/pleezer).

The `rebuilder.lib` is updated to have `rustc` 1.82 as minimum requirement.

