### PR TITLE
[alsa-lib] Publish the three binaries the source produces

### DIFF
--- a/packages/alsa-lib/build.sh
+++ b/packages/alsa-lib/build.sh
@@ -76,7 +76,24 @@ done
 # set debian local suffix flag
 DEBFULLNAME=$DEBFULLNAME DEBEMAIL=$DEBEMAIL dch --local $DEBSUFFIX "Added PCM meter scope patches: no abort on unconvertible formats, DSD levels"
 
+# read back from the changelog: FULL_VERSION does not carry the local suffix here,
+# the distro revision (1+rpt1) already fills the field it is decoded from
+DEB_VERSION=`dpkg-parsechangelog -S Version`
+
 #------------------------------------------------------------
 
 rbl_build
+
+# This source produces several binaries that have to be published together:
+# libasound2-dev Depends: libasound2t64 (= ${binary:Version}). A repo holding the
+# patched library without its matching -dev makes apt remove libasound2-dev, and
+# every later build needing it fails. deploy.sh takes one package per run and
+# matches on the file name, and alsa-lib is not one of the binary names.
+echo "${GREEN}Publish with:${NORMAL}"
+echo "  ../../scripts/deploy.sh ${PKGNAME}_${DEB_VERSION}"
+for binary in libasound2t64 libasound2-data libasound2-dev
+do
+    echo "  ../../scripts/deploy.sh ${binary}_${DEB_VERSION}"
+done
+
 echo "done"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -82,7 +82,7 @@ then
 fi
 
 DEB=`find ./dist/binary -maxdepth 1 -name "$PKG*.deb" ! -name "$PKG-dbgsym*.deb"`
-DEB_COUNT=`find ./dist/binary -maxdepth 1 -name "$PKG*.deb" | wc -l`
+DEB_COUNT=`find ./dist/binary -maxdepth 1 -name "$PKG*.deb" ! -name "$PKG-dbgsym*.deb" | wc -l`
 
 DSC=`find ./dist/source -maxdepth 1 -name "$PKG*.dsc"`
 DEBIAN=`find ./dist/source -maxdepth 1 -name "$PKG*.debian*"`
@@ -90,8 +90,11 @@ SRC=`find ./dist/source -maxdepth 1 -name "$PKG*.orig*" ! -name "$PKG*.asc"`
 
 if [ $DEB_COUNT -gt 1 ]
 then
-    echo "${YELLOW}Multiple packages found to upload, not supported.${NORMAL}"
-    echo $DEB
+    echo "${YELLOW}Multiple packages found to upload, not supported. Run one per package:${NORMAL}"
+    for FOUND in $DEB
+    do
+        echo "  deploy.sh `basename $FOUND | sed -r 's/^(.*)_[^_]*\.deb$/\1/'`"
+    done
     deactivate
     exit 1
 fi

--- a/scripts/rebuilder.lib.sh
+++ b/scripts/rebuilder.lib.sh
@@ -273,7 +273,7 @@ function rbl_move_to_dist {
     mkdir -p $BASE_DIR/dist/binary
     mv -f $BUILD_ROOT_DIR/*$PKGVERSION*.orig.* $BASE_DIR/dist/source > /dev/null 2>&1
     mv -f $BUILD_ROOT_DIR/*$PKGVERSION*$DEBLOC*.dsc $BASE_DIR/dist/source > /dev/null 2>&1
-    mv -f $BUILD_ROOT_DIR/*$PKGVERSION*$DEBLOC.debian.* $BASE_DIR/dist/source > /dev/null 2>&1
+    mv -f $BUILD_ROOT_DIR/*$PKGVERSION*$DEBLOC*.debian.* $BASE_DIR/dist/source > /dev/null 2>&1
     mv $BUILD_ROOT_DIR/*$PKGVERSION-$DEBVER$DEBLOC* $BASE_DIR/dist/binary > /dev/null 2>&1
     mv $BUILD_ROOT_DIR/$PKGNAME-$PKGVERSION/*$PKGVERSION-$DEBVER$DEBLOC* $BASE_DIR/dist/binary > /dev/null 2>&1
 }


### PR DESCRIPTION
The source builds libasound2t64, libasound2-data and libasound2-dev, and their dependencies lock them together: -dev needs the exact t64 version, t64 needs -data at least the same. The build now prints the four deploy.sh commands, one per binary plus the source.

Two things found while checking that on a Pi build:

rbl_move_to_dist left the .debian.tar.* in dist/binary when the revision already carries a local suffix (1.2.14-1+rpt1 → 1.2.14-1+rpt1moode1) — the .dsc glob has a wildcard the tarball glob lacks — so deploy.sh reported "No source found" and pushed no source at all.
deploy.sh counted the dbgsym deb that the line above already excludes, so a package name without its version hit "Multiple packages found"; it now lists the commands to run instead.