### PR TITLE
[rebuilder.lib.sh] Fix the cargo toolchain check, and cap librespot's build parallelism

### DIFF
--- a/packages/librespot/build.sh
+++ b/packages/librespot/build.sh
@@ -33,6 +33,24 @@ then
     exit
 fi
 
+# Cap build parallelism to the board's RAM, not its core count. cargo
+# defaults to one rustc per core (nproc); on low-RAM Pis (3A+/Zero 2 W =
+# 4 cores / 512 MB) that stacks 4 rustc and thrashes swap. Budget 512 MB
+# per parallel rustc, clamp to [1, nproc]: 512 MB -> 1 job, 1 GB -> 2,
+# 2 GB and up -> 4. An explicit CARGO_BUILD_JOBS from the environment
+# always wins.
+if [[ -z "$CARGO_BUILD_JOBS" ]]
+then
+    MEM_MB=`awk '/MemTotal/ {print int($2 / 1024)}' /proc/meminfo`
+    # the +512 absorbs what MemTotal under-reports (CMA/GPU reserved), so
+    # that a 1 GB board announcing ~905 MB still lands on 2 jobs.
+    CARGO_BUILD_JOBS=$(( (MEM_MB + 512) / 512 ))
+    [[ $CARGO_BUILD_JOBS -lt 1 ]] && CARGO_BUILD_JOBS=1
+    [[ $CARGO_BUILD_JOBS -gt `nproc` ]] && CARGO_BUILD_JOBS=`nproc`
+    export CARGO_BUILD_JOBS
+fi
+echo "${YELLOW}building librespot with CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS} (RAM ${MEM_MB:-?}MB, `nproc` cores)${NORMAL}"
+
 # rustup default stable-aarch64-unknown-linux-gnu
 RUSTFLAGS='-Ccodegen-units=1' cargo-deb -- --features alsa-backend
 

--- a/scripts/rebuilder.lib.sh
+++ b/scripts/rebuilder.lib.sh
@@ -293,63 +293,83 @@ function _rebuild {
 }
 
 function rbl_check_cargo {
-	# Set paths
-	if [[ $EUID -ne 0 ]]; then
-		echo "${GREEN}Running as user on a build machine${NORMAL}"
-		BASE_PATH=""
-		CARGO_PATH="/home/pi/.cargo/bin/"
-	else
-		echo "${GREEN}Running as root for the on-demand-install from Renderer Config${NORMAL}"
-		BASE_PATH="/root/.cargo/bin/"
-		CARGO_PATH=$BASE_PATH
-	fi
-
-	# Env
-	export RUSTUP_UNPACK_RAM=94371840; export RUSTUP_IO_THREADS=1
-	# Prepend: a distro rustc in /usr/bin must not shadow the rustup one,
-	# otherwise the version check below reads the wrong rustc and the
-	# toolchain gets uninstalled and reinstalled on every build.
-	export PATH=$CARGO_PATH:$PATH
+	# Specify version to avoid the issue in 1.97 causing segfaults
 	RUSTC_PIN_VERSION="1.96.0"
 
-	# Cargo+rust
-	if [[ -f $CARGO_PATH"rustup" ]]
+	# The toolchain lives in a different place depending on how the build
+	# was started, so pin CARGO_HOME explicitly for both contexts and let
+	# every step below work off it. rustup, cargo and the env script all
+	# honour CARGO_HOME, so nothing has to guess a path afterwards.
+	if [[ $EUID -ne 0 ]]
 	then
-		INSTALLED_RUSTC_VERSION=$($BASE_PATH"rustc" --version | sed -r "s/rustc[ ]([0-9]+[.][0-9]+[.][0-9]+).*/\1/")
-		if [[ $INSTALLED_RUSTC_VERSION == $RUSTC_PIN_VERSION ]]
+		echo "${GREEN}Running as user on a build machine${NORMAL}"
+		# Not /home/pi: since Bookworm the account is created at first
+		# boot, so the build user is whoever is logged in
+		if [[ -z "$HOME" ]]
 		then
-			echo "${GREEN}cargo+rust $RUSTC_PIN_VERSION is already installed${NORMAL}"
-		else
-			echo "${YELLOW}cargo+rust install is not the correct version, removing it${NORMAL}"
-			$BASE_PATH"rustup" self uninstall -y
-
-			echo "${YELLOW}installing cargo+rust $RUSTC_PIN_VERSION${NORMAL}"
-			curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=$RUSTC_PIN_VERSION -y
-			source $HOME/.cargo/env
+			echo "${RED}exiting build: HOME is not set, cannot locate the cargo install${NORMAL}"
+			exit 1
 		fi
+		export CARGO_HOME="$HOME/.cargo"
 	else
+		echo "${GREEN}Running as root for the on-demand-install from Renderer Config${NORMAL}"
+		# Spelled out rather than $HOME: the moode worker that runs the
+		# on-demand build does not necessarily export it
+		export CARGO_HOME="/root/.cargo"
+	fi
+	CARGO_PATH="$CARGO_HOME/bin"
+
+	export RUSTUP_UNPACK_RAM=94371840; export RUSTUP_IO_THREADS=1
+	# Prepend so that a distro rustc in /usr/bin cannot shadow the pinned one
+	export PATH="$CARGO_PATH:$PATH"
+
+	# Ask the toolchain we manage, by full path, so the answer does not
+	# depend on what else is installed on the machine
+	INSTALLED_RUSTC_VERSION=""
+	if [[ -x "$CARGO_PATH/rustc" ]]
+	then
+		INSTALLED_RUSTC_VERSION=`"$CARGO_PATH/rustc" --version 2>/dev/null | sed -r "s/rustc[ ]([0-9]+[.][0-9]+[.][0-9]+).*/\1/"`
+	fi
+
+	if [[ "$INSTALLED_RUSTC_VERSION" == "$RUSTC_PIN_VERSION" ]]
+	then
+		echo "${GREEN}cargo+rust $RUSTC_PIN_VERSION is already installed${NORMAL}"
+	else
+		# Clean out whatever is there before installing the pinned version
+		if [[ -x "$CARGO_PATH/rustup" ]]
+		then
+			echo "${YELLOW}removing cargo+rust ${INSTALLED_RUSTC_VERSION:-(unknown version)}${NORMAL}"
+			"$CARGO_PATH/rustup" self uninstall -y
+		fi
+		# An interrupted install leaves a CARGO_HOME with no rustup in it
+		# to uninstall with, and rustup-init will not install over it
+		if [[ -d "$CARGO_HOME" ]]
+		then
+			echo "${YELLOW}removing leftover $CARGO_HOME${NORMAL}"
+			rm -rf "$CARGO_HOME"
+		fi
+
 		echo "${YELLOW}installing cargo+rust $RUSTC_PIN_VERSION${NORMAL}"
 		curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=$RUSTC_PIN_VERSION -y
-		source $HOME/.cargo/env
+		source "$CARGO_HOME/env"
 	fi
 
 	# The pin exists to avoid the segfaults in 1.97, so don't build at all
 	# if the install we ended up with isn't it
-	INSTALLED_RUSTC_VERSION=$($BASE_PATH"rustc" --version | sed -r "s/rustc[ ]([0-9]+[.][0-9]+[.][0-9]+).*/\1/")
-	if [[ $INSTALLED_RUSTC_VERSION != $RUSTC_PIN_VERSION ]]
+	INSTALLED_RUSTC_VERSION=`"$CARGO_PATH/rustc" --version 2>/dev/null | sed -r "s/rustc[ ]([0-9]+[.][0-9]+[.][0-9]+).*/\1/"`
+	if [[ "$INSTALLED_RUSTC_VERSION" != "$RUSTC_PIN_VERSION" ]]
 	then
-		echo "${RED}exiting build: installed rust version $INSTALLED_RUSTC_VERSION is not the required version $RUSTC_PIN_VERSION${NORMAL}"
+		echo "${RED}exiting build: installed rust version ${INSTALLED_RUSTC_VERSION:-none} is not the required version $RUSTC_PIN_VERSION${NORMAL}"
 		exit 1
 	fi
 
-	# Cargo-deb
-	CARGO_DEB_VER=$($BASE_PATH"cargo-deb" --version > /dev/null 2>&1)
-	if [[ $? -gt 0 ]]
+	# Cargo-deb, which rustup self uninstall takes down with the toolchain
+	if "$CARGO_PATH/cargo-deb" --version > /dev/null 2>&1
 	then
-		echo "${YELLOW}cargo-deb is not installed, installing it${NORMAL}"
-		$BASE_PATH"cargo" install cargo-deb
-	else
 		echo "${GREEN}cargo-deb is already installed${NORMAL}"
+	else
+		echo "${YELLOW}cargo-deb is not installed, installing it${NORMAL}"
+		"$CARGO_PATH/cargo" install cargo-deb
 	fi
 }
 

--- a/scripts/rebuilder.lib.sh
+++ b/scripts/rebuilder.lib.sh
@@ -306,7 +306,10 @@ function rbl_check_cargo {
 
 	# Env
 	export RUSTUP_UNPACK_RAM=94371840; export RUSTUP_IO_THREADS=1
-	export PATH=$PATH:$CARGO_PATH
+	# Prepend: a distro rustc in /usr/bin must not shadow the rustup one,
+	# otherwise the version check below reads the wrong rustc and the
+	# toolchain gets uninstalled and reinstalled on every build.
+	export PATH=$CARGO_PATH:$PATH
 	RUSTC_PIN_VERSION="1.96.0"
 
 	# Cargo+rust
@@ -329,6 +332,16 @@ function rbl_check_cargo {
 		curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=$RUSTC_PIN_VERSION -y
 		source $HOME/.cargo/env
 	fi
+
+	# The pin exists to avoid the segfaults in 1.97, so don't build at all
+	# if the install we ended up with isn't it
+	INSTALLED_RUSTC_VERSION=$($BASE_PATH"rustc" --version | sed -r "s/rustc[ ]([0-9]+[.][0-9]+[.][0-9]+).*/\1/")
+	if [[ $INSTALLED_RUSTC_VERSION != $RUSTC_PIN_VERSION ]]
+	then
+		echo "${RED}exiting build: installed rust version $INSTALLED_RUSTC_VERSION is not the required version $RUSTC_PIN_VERSION${NORMAL}"
+		exit 1
+	fi
+
 	# Cargo-deb
 	CARGO_DEB_VER=$($BASE_PATH"cargo-deb" --version > /dev/null 2>&1)
 	if [[ $? -gt 0 ]]

--- a/scripts/rebuilder.lib.sh
+++ b/scripts/rebuilder.lib.sh
@@ -323,6 +323,13 @@ function rbl_check_cargo {
 	# Prepend so that a distro rustc in /usr/bin cannot shadow the pinned one
 	export PATH="$CARGO_PATH:$PATH"
 
+	# On aarch64 a codegen worker thread can overflow its stack and take rustc
+	# down with SIGSEGV inside LLVM, on generated code with very large functions
+	# (librespot-protocol). Not the OOM killer, not governed by the job count,
+	# so it strikes at random. 16 MiB is what rustc's own diagnostic suggests,
+	# and a thread stack is reserved address space - pages cost only when used.
+	export RUST_MIN_STACK=${RUST_MIN_STACK:-16777216}
+
 	# Ask the toolchain we manage, by full path, so the answer does not
 	# depend on what else is installed on the machine
 	INSTALLED_RUSTC_VERSION=""


### PR DESCRIPTION
Two independent failures on the on-demand librespot build, one fix each.
Measured on Pi 3B, 3B+, 3A+, Zero 2 W, Pi 4 and Pi 5, all rustc 1.96.0.

## `rbl_check_cargo` never finds an existing toolchain

It looked under `/home/pi`. Since Bookworm the account is created at first
boot, so on a device whose user is not `pi` the check finds nothing: every CLI
build re-downloads the whole toolchain and cargo-deb, installs it into
`$HOME/.cargo`, and finds nothing again on the next run. Verified on a Trixie
device where `/home/pi` does not exist.

`CARGO_HOME` is now derived once for both contexts — `$HOME/.cargo` for user
builds, `/root/.cargo` for the on-demand install spawned by the worker — and
every step works off it. Along the way:

- prepend the cargo bin dir to `PATH`, so a distro `/usr/bin/rustc` cannot
  shadow the pinned one and trigger a reinstall on every build
- remove a leftover `CARGO_HOME` that has no rustup left in it to uninstall
  with, which rustup-init refuses to install over
- re-check the version after installing and exit 1 on mismatch: the pin exists
  to avoid the 1.97 segfaults

Checked as both user and root for: nothing installed, pinned version already
installed, wrong version installed, leftover `CARGO_HOME`, and an install that
yields the wrong version.

## Low-RAM boards

**Jobs.** cargo defaults to one rustc per core. On a 1 GB Pi 3B that stacks
four rustc and drives the board into SD thrash. Budget 512 MB per parallel
rustc, clamped to `[1, nproc]`; an explicit `CARGO_BUILD_JOBS` still wins.
One board, one variable:

| jobs | time | written to card |
| --- | --- | --- |
| 1 | 53m10 | 1931 MB |
| 2 | **39m42** | 3635 MB |
| 3 | 39m26 | 4705 MB |

Two is the knee — a third job saves 16 s and writes 29% more.

**Stack.** On aarch64 a codegen worker thread can overflow its stack and take
rustc down with SIGSEGV inside LLVM while compiling `librespot-protocol`. It is
not the OOM killer and not governed by the job count, so it strikes at random.
`RUST_MIN_STACK=16777216` is the remedy rustc's own diagnostic suggests, and it
costs no measurable time: the same board run twice, once each way, gave 21m19
against 21m16 on a Pi 4 and 7m13 against 7m12 on a Pi 5.

Together they bring back builds that had stopped completing: a Pi 3A+ and a
Zero 2 W (512 MB) finish at one job, and a 1 GB Pi 3B+ that had failed several
attempts finished the same way. Not a guarantee — one 512 MB board has still
failed with both applied.

`rbl_check_cargo` is shared, so pleezer and camilladsp get the raised stack too
when they are built. The job budget stays in `packages/librespot/build.sh`,
where it was measured, and where the build runs on the user's own board.
